### PR TITLE
Make it work with CUDA 12.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ $(TARGET): $(SRC)
 
 # Rule for running the application
 run: $(TARGET)
-	./$(TARGET) --input $(DATA_DIR)/Lena.png --output $(DATA_DIR)/Lena_rotated.png
+	./$(TARGET) --input $(DATA_DIR)/Lena.png --output $(DATA_DIR)/Lena_rotated.png --angle=10
 
 # Clean up
 clean:


### PR DESCRIPTION
This repo is forked from https://github.com/PascaleCourseraCourses/CUDAatScaleForTheEnterpriseCourseProjectTemplate

With my setup (ubuntu24.04, nvidia drivers 555, cuda 12.5) the code does not build as is. The goal of this PR is to make it build. It turns out that the interface of NPP lib functions that was used before is not compatible with the interfaces available in cuda 12.5. 
