### PR TITLE
add prototype for video processing using opencv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@
 NVCC = /usr/local/cuda/bin/nvcc
 CXX = g++
 CXXFLAGS = -std=c++11 -I/usr/local/cuda/include -Iinclude
-LDFLAGS = -L/usr/local/cuda/lib64 -lcudart -lnppc -lnppial -lnppicc -lnppidei -lnppif -lnppig -lnppim -lnppist -lnppisu -lnppitc
+LDFLAGS = -L/usr/local/cuda/lib64 -lcudart -lnppc -lnppial -lnppicc -lnppidei -lnppif -lnppig -lnppim -lnppist -lnppisu -lnppitc -lfreeimage `pkg-config --cflags --libs opencv4`
 
 # Define directories
 SRC_DIR = src


### PR DESCRIPTION
This PR adds a prototype for applying the filter on a video file. The file handling is done using opencv. The single-image processing is commented out for now, however, in a subsequent refactoring step, it will be enabled again.